### PR TITLE
Minor doc edits

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -4,6 +4,8 @@ date:
 draft: false
 ---
 
-`pg_tileserv` is a [PostGIS](https://postgis.net/)-only tile server in [Go](https://golang.org/).
- Strip away all the other requirements, it just has to take in HTTP tile request
-s and form and execute SQL.  In a sincere act of flattery, the API and design look a lot like that of the [Martin](https://github.com/urbica/martin) tile server.
+# pg_tileserv
+
+`pg_tileserv` is a [PostGIS](https://postgis.net/)-only tile server in [Go](https://golang.org/). Strip away all the other requirements, it just has to take in HTTP tile requests and form and execute SQL.  In a sincere act of flattery, the API and design look a lot like that of the [Martin](https://github.com/urbica/martin) tile server.
+
+This guide will walk you through how to install and use `pg_tileserv` for your spatial applications. The [Usage](./usage) section goes in-depth on how the service works. We also include some [basic examples](./examples) of web maps that render tiles from `pg_tileserv`.

--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -24,7 +24,9 @@ LIBPROTOBUF="1.3.2" WAGYU="0.4.3 (Internal)"
 
 ## Installation
 
-### Download Binaries
+To install `pg_tileserv`, download the binary file. Alternatively, you may run a container, or build the executable from source.
+
+### A. Download Binaries
 
 Builds of the latest code:
 
@@ -34,21 +36,21 @@ Builds of the latest code:
 
 Unzip the file, copy the `pg_tileserv` binary wherever you wish, or use it in place. If you move the binary, remember to move the `assets/` directory to the same location, or start the server using the `AssetsDir` configuration option.
 
-### Run Container
+### B. Run Container
 
 There is a docker image available on DockerHub.
 
 * [Docker](https://hub.docker.com/repository/docker/pramsey/pg_tileserv)
 
-Run the container, provide database connection information in the `DATABASE_URL` and map the default service port (7800).
+Run the container, provide database connection information in the `DATABASE_URL` environment variable and map the default service port (7800).
 
 ```sh
 docker run -e DATABASE_URL=postgres://user:pass@host/dbname -p 7800:7800 pramsey/pg_tileserv
 ```
 
-### Build From Source
+### C. Build From Source
 
-Install the [Go software development environment](https://golang.org/doc/install).
+Install the [Go software development environment](https://golang.org/doc/install). Make sure that the [`GOPATH` environment variable](https://github.com/golang/go/wiki/SettingGOPATH) is also set.
 
 ```sh
 SRC=$GOPATH/src/github.com/CrunchyData
@@ -60,7 +62,7 @@ go build
 go install
 ```
 
-To run the build, set the `DATABASE_URL` to the database you want to connect to, and run the binary.
+To run the build, set the `DATABASE_URL` environment variable to the database you want to connect to, and run the binary.
 
 ```sh
 export DATABASE_URL=postgres://user:pass@host/dbname
@@ -83,13 +85,6 @@ export DATABASE_URL=postgresql://username:password@host/dbname
 ```
 SET DATABASE_URL=postgresql://username:password@host/dbname
 pg_tileserv.exe
-```
-
-### Trouble-shooting
-
-To get more information about what is going on behind the scenes, run with the `--debug` commandline parameter on, or turn on debugging in the configuration file:
-```sh
-./pg_tileserv --debug
 ```
 
 ### Configuration File
@@ -136,5 +131,3 @@ DefaultMaxZoom = 22
 # Output extra logging information?
 Debug = false
 ```
-
-

--- a/docs/content/introduction/_index.md
+++ b/docs/content/introduction/_index.md
@@ -1,13 +1,9 @@
 ---
-title: "Introduction"
+title: "About pg_tileserv"
 date:
 draft: false
 weight: 10
 ---
-
-`pg_tileserv` is a [PostGIS](https://postgis.net/)-only tile server in [Go](https://golang.org/).
- Strip away all the other requirements, it just has to take in HTTP tile request
-s and form and execute SQL.  In a sincere act of flattery, the API and design look a lot like that of the [Martin](https://github.com/urbica/martin) tile server.
 
 ## Motivation
 

--- a/docs/content/introduction/_index.md
+++ b/docs/content/introduction/_index.md
@@ -7,10 +7,12 @@ weight: 10
 
 ## Motivation
 
-There are already lots of tile generators out there ([Tegola](https://tegola.io/), [Geoserver](https://geoserver.org), [Mapserver](https://mapserver.org)) that read from multiple data sources and generate vector tiles. In exchange for that flexibility of format, they provide less flexibility of usage. By restricting itself to only using PostGIS as a data source, `pg_tileserv` gains the following features:
+There are already lots of tile generators out there ([Tegola](https://tegola.io/), [Geoserver](https://geoserver.org), [Mapserver](https://mapserver.org)) that read from multiple data sources and generate vector tiles. In exchange for that flexibility of format, they provide less flexibility of usage. 
+
+By restricting itself to only using PostGIS as a data source, `pg_tileserv` gains the following features:
 
 * **Automatic configuration.** Just point the server at a PostgreSQL / PostGIS database, and the server can discover and automatically publish as tiles sources all tables it has read access to.
-* **Full SQL flexibility.** Using [function layers]() the server can run any SQL at all to generate tile outputs. Any data processing or feature filtering or record aggregation you can express in SQL, you can expose as parameterized tile sources.
+* **Full SQL flexibility.** Using [function layers](), the server can run any SQL at all to generate tile outputs. Any data processing or feature filtering or record aggregation you can express in SQL, you can expose as parameterized tile sources.
 * **Database security model.** You can restrict access to tables and functions using standard database access control. This means you can also use advanced access control techniques, like row-level security to dynamically filter access based on the login role.
 
 ## Architecture
@@ -25,7 +27,6 @@ It should be possible to stand up a spatial services architecture of stateless m
 
 ## Definitions
 
-* **Map tiles** are a way of representing a multi-scale, [zoomable cartographic map](https://en.wikipedia.org/wiki/Tiled_web_map) by regularly subidividing the plane into independent tiles that can then rendered on a server and retrieved by a map client in parallel.
+* **Map tiles** are a way of representing a multi-scale, [zoomable cartographic map](https://en.wikipedia.org/wiki/Tiled_web_map) by regularly subidividing the plane into independent tiles that can then be rendered on a server and retrieved by a map client in parallel.
 * **Vector tiles** are a [specific format of map tile](https://docs.mapbox.com/vector-tiles/specification/) that encode the features as vectors and delegate rendering of the features into cartography to the client web browser. Client side vector rendering uses less bandwidth, which is good for mobile clients, and allow more options for client side dynamic data visualizations.
 * A **spatial database** is a database that includes a "geometry" column type. The PostGIS extension to PostgreSQL adds a geometry column type, and hundreds of functions to operate on that type, including the [ST_AsMVT()](https://postgis.net/docs/ST_AsMVT.html) function that `pg_tileserv` depends upon.
-

--- a/docs/content/troubleshooting/_index.md
+++ b/docs/content/troubleshooting/_index.md
@@ -7,7 +7,7 @@ weight: 50
 
 ## Tile Server
 
-To get more information about what is going on behind the scenes, run with the `--debug` commandline parameter on, or turn on debugging in the configuration file:
+To get more information about what is going on behind the scenes, run the server with the `--debug` commandline parameter on, or turn on debugging in the configuration file:
 ```sh
 ./pg_tileserv --debug
 ```

--- a/docs/content/usage/function-layers-advanced.md
+++ b/docs/content/usage/function-layers-advanced.md
@@ -7,7 +7,7 @@ weight: 400
 
 ## Dynamic Geometry Example
 
-So far all our examples have used simple SQL functions, but using the more [procedural PL/PgSQL language](https://www.postgresql.org/docs/current/plpgsql.html) we can create much more interactive examples.
+So far all our examples have used simple SQL functions, but using the procedural [PL/pgSQL language](https://www.postgresql.org/docs/current/plpgsql.html) we can create much more interactive examples.
 
 ```sql
 CREATE OR REPLACE
@@ -108,7 +108,7 @@ SELECT ST_AsText(hexagon(2, 2, 10.0));
           35 43.3012701892219,25 43.3012701892219,
           20 34.6410161513775))
 ```
-Now we need a function that, given a square input (a map tile) can figure out all the hexagon coordinates that fall within the tile. Again, the edge size of the hexagon tiling determines the overall geometry of the hex tiling. More than one hexagon will be required, most times, so this is a set-returning function.
+Now we need a function that, given a square input (a map tile), can figure out all the hexagon coordinates that fall within the tile. Again, the edge size of the hexagon tiling determines the overall geometry of the hex tiling. More than one hexagon will be required most times, so this is a set-returning function.
 ```sql
 -- Given a square bounds, find all the hexagonal cells
 -- of a hex tiling (determined by edge size)
@@ -151,7 +151,7 @@ SELECT * FROM hexagoncoordinates(ST_TileEnvelope(15, 1, 1), 1000.0);
  -13356 | 11567
  -13356 | 11568
 ```
-Next, a function that puts the two parts together. With tile coordinates and edge size as input, generate the set of all the hexagons that cover the tile. The output here is basically a spatial table: a set of rows, each row containing a geometry (hexagon) and some properties (hexagon coordinates). Just the input we need for a spatial join.
+Next, we need a function that puts the two parts together: with tile coordinates and edge size as input, generate the set of all the hexagons that cover the tile. The output here is basically a spatial table--a set of rows, each row containing a geometry (hexagon) and some properties (hexagon coordinates). This is the input we need for a spatial join.
 ```sql
 -- Given an input ZXY tile coordinate, output a set of hexagons
 -- (and hexagon coordinates) in web mercator that cover that tile
@@ -182,7 +182,7 @@ IMMUTABLE
 STRICT
 PARALLEL SAFE;
 ```
-The function that the tile server actually calls looks like all other tile server functions: tile coordinates and optional parameter input; `bytea` MVT output.
+The function that the tile server actually calls looks like all other tile server functions: tile coordinates and optional parameter as input, `bytea` MVT as output.
 ```sql
 -- Given an input tile, generate the covering hexagons,
 -- spatially join to population table, summarize

--- a/docs/content/usage/function-layers.md
+++ b/docs/content/usage/function-layers.md
@@ -7,7 +7,7 @@ weight: 300
 
 ## Function Layer Detail JSON
 
-In the detail JSON, each function declares information relevant to setting up a map interface for the layer. Because functions generate tiles dynamically, the system cannot auto-discover things like extent or center, unfortunately. However, the custom parameters and defaults can be read from the function definition and exposed in the detail JSON.
+In the detail JSON, each function declares information relevant to setting up a map interface for the layer. Because functions generate tiles dynamically, the system cannot auto-discover things like extent or center. However, the custom parameters and defaults can be read from the function definition and exposed in the detail JSON.
 ```json
 {
    "name" : "parcels_in_radius",
@@ -73,6 +73,7 @@ PARALLEL SAFE;
 COMMENT ON FUNCTION public.countries_name IS 'Filters the countries table by the initial letters of the name using the "name_prefix" parameter.';
 ```
 Some notes about this function:
+
 * The `ST_AsMVT()` function uses the function name ("public.countries_name") as the MVT layer name. This is not required, but for clients that self-configure, it allows them to use the function name as the layer source name.
 * In the filter portion of the query (in the `WHERE` clause) the bounds are transformed to the spatial reference of the table data (4326) so that the spatial index on the table geometry can be used.
 * In the `ST_AsMVTGeom()` portion of the query, the table geometry is transformed into web mercator ([3857](https://epsg.io/3857)) to match the bounds, and the _de facto_ expectation that MVT tiles are delivered in web mercator projection.
@@ -102,7 +103,7 @@ Some notes about this function:
   STRICT
   PARALLEL SAFE;
   ```
-* The `LIMIT` is hard-coded in this example. If you want a user-defined limit you need to add another parameter to your function definition.
+* The `LIMIT` is hard-coded in this example. If you want a user-defined limit, you need to add another parameter to your function definition.
 * The function "[volatility](https://www.postgresql.org/docs/current/xfunc-volatility.html)" is declared as `STABLE` because within one transaction context, multiple runs with the same inputs will return the same outputs. It is not marked as `IMMUTABLE` because changes in the base table can change the outputs over time, even for the same inputs.
 * The function is declared as `PARALLEL SAFE` because it doesn't depend on any global state that might get confused by running multiple copies of the function at once.
 
@@ -148,6 +149,7 @@ PARALLEL SAFE;
 COMMENT ON FUNCTION public.parcels_in_radius IS 'Given the click point (click_lon, click_lat) and radius, returns all the parcels in the radius, clipped to the radius circle.';
 ```
 Notes:
+
 * The parcels are stored in a table with spatial reference system [3005](https://epsg.io/3005), a planar projection.
 * The click parameters are longitude/latitude, so in building a click geometry (`ST_MakePoint()`) to use for querying, we transform the geometry to the table spatial reference.
 * To get the parcel boundaries clipped to the radius, we build a circle in the native spatial reference (26910) using the `ST_Buffer()` function on the click point, then intersect that circle with the parcels.

--- a/docs/content/usage/metadata.md
+++ b/docs/content/usage/metadata.md
@@ -10,11 +10,11 @@ You can explore the contents of the tile server using:
 * an HTML web interface for humans; and
 * a JSON API for computers.
 
-The JSON API is useful for clients that auto-configure based on the service metadata, and in fact the HTML web interface is an example of just such an auto-configuring interface: it reads the JSON and uses that to set up the web map visualization and interface elements.
+The JSON API is useful for clients that auto-configure based on the service metadata. In fact, the HTML web interface is an example of such an auto-configuring interface: it reads the JSON and uses that to set up the web map visualization and interface elements.
 
 ## Web Interface
 
-After start-up you can connect to the server and explore the published tables and functions in the database via a web interface at:
+After start-up, you can connect to the server and explore the published tables and functions in the database via a web interface at:
 
 * http://localhost:7800
 

--- a/docs/content/usage/security.md
+++ b/docs/content/usage/security.md
@@ -9,7 +9,7 @@ The basic principle of security is to connect your tile server to the database w
 ```sql
 CREATE USER tileserver;
 ```
-Start with a blank user. A blank user will have no select privileges on tables it does not own. It will have execute privileges on functions. However, any the user will have no select privileges on tables accessed by functions, so effectively the user will still have no access to data.
+Start with a blank user. A blank user will have no select privileges on tables it does not own. It will have execute privileges on functions. However, the user will have no select privileges on tables accessed by functions, so effectively the user will still have no access to data.
 
 ## Tables
 
@@ -21,14 +21,14 @@ You can then grant access to the user one table at a time.
 ```sql
 GRANT SELECT ON TABLE myschema.mytable TO tileserver;
 ```
-Or grant access to all the tables at once.
+Alternatively, you can grant access to all the tables at once.
 ```sql
 GRANT SELECT ON ALL TABLES IN SCHEMA myschema TO tileserver;
 ```
 
 ## Functions
 
-As noted above, functions that access table data effectively are restricted by the access levels the user has to the tables the function reads. However, if you want to completely restrict access to the function, including visibility in the user interface, you can strip execution privileges from the function.
+As noted above, functions that access table data effectively are restricted by the access levels the user has to the tables the function reads. If you want to completely restrict access to the function, including visibility in the user interface, you can strip execution privileges from the function.
 ```sql
 -- All functions grant execute to 'public' and all roles are
 -- part of the 'public' group, so public has to be removed

--- a/docs/content/usage/table-layers.md
+++ b/docs/content/usage/table-layers.md
@@ -5,12 +5,12 @@ draft: false
 weight: 200
 ---
 
-By default, `pg_tileserv` will provide access to **only** those spatial tables:
+By default, `pg_tileserv` will provide access to **only** those spatial tables that:
 
-* that your database connection has `SELECT` privileges for;
-* that include a geometry column;
-* that declare a geometry type; and,
-* that declare an SRID (spatial reference ID)
+* your database connection has `SELECT` privileges for;
+* include a geometry column;
+* declare a geometry type; and,
+* declare an SRID (spatial reference ID)
 
 For example:
 ```sql


### PR DESCRIPTION
- Renamed Intro page to "About pg_tileserv" -> this seems to be more meaningful
- Small text edits throughout (add punctuation marks, remove a few extra modifiers, etc)