### PR TITLE
Small fixes for server errors

### DIFF
--- a/layer_table.go
+++ b/layer_table.go
@@ -381,11 +381,11 @@ func (lyr *LayerTable) requestSql(tile *Tile, qp *queryParameters) (string, erro
 	tmplSql := `
 	SELECT ST_AsMVT(mvtgeom, {{ .MvtParams }}) FROM (
 		SELECT ST_AsMVTGeom(
-			ST_Transform(t.{{ .GeometryColumn }}, 3857),
+			ST_Transform(t."{{ .GeometryColumn }}", 3857),
 			bounds.geom_clip,
 			{{ .Resolution }},
 			{{ .Buffer }}
-		  ) AS {{ .GeometryColumn }}
+		  ) AS "{{ .GeometryColumn }}"
 		  {{ if .Properties }}
 		  , {{ .Properties }}
 		  {{ end }}
@@ -393,7 +393,7 @@ func (lyr *LayerTable) requestSql(tile *Tile, qp *queryParameters) (string, erro
 			SELECT {{ .TileSql }}  AS geom_clip,
 					{{ .QuerySql }} AS geom_query
 			) bounds
-		WHERE ST_Intersects(t.{{ .GeometryColumn }},
+		WHERE ST_Intersects(t."{{ .GeometryColumn }}",
 							ST_Transform(bounds.geom_query, {{ .Srid }}))
 		{{ .Limit }}
 	) mvtgeom

--- a/layer_table.go
+++ b/layer_table.go
@@ -234,7 +234,7 @@ func (lyr *LayerTable) GetBoundsExact() (Bounds, error) {
 		SELECT
 			coalesce(
 				ST_Transform(ST_SetSRID(ST_Extent("%s"), %d), 4326),
-				ST_MakeEnvelope(0, 0, 0, 0, 4326)
+				ST_MakeEnvelope(-180, -90, 180, 90, 4326)
 			) AS geom
 		FROM "%s"."%s"
 	)


### PR DESCRIPTION
This PR has 2 small fixes for server errors I bumped into:

1. added default bounds (0,0,0,0) if the ST_Extent query in GetBoundsExact() returns a null value, which was causing a 500 error.  This is reproducible by using the preview or getting JSON for an empty table.  Any comments on whether returning default bounds of `[0,0,0,0]` and center `[0, 0]` is a good option (versus, say returning `null`, or doing something else if the table is empty)?

I also removed the `xmin` null check since it should be redundant if the above change makes sense.

2. added parentheses around the geometry column in the SQL template