### PR TITLE
Fixes for function arguments

### DIFF
--- a/layer_proc.go
+++ b/layer_proc.go
@@ -40,7 +40,7 @@ type FunctionDetailJson struct {
 	Schema      string             `json:"schema"`
 	Name        string             `json:"name"`
 	Description string             `json:"description,omitempty"`
-	Arguments   []FunctionArgument `json:"arguments,omitempty"`
+	Arguments   []FunctionArgument `json:"arguments"`
 	MinZoom     int                `json:"minzoom"`
 	MaxZoom     int                `json:"maxzoom"`
 	TileUrl     string             `json:"tileurl"`
@@ -143,6 +143,7 @@ func (lyr *LayerFunction) getFunctionDetailJson(req *http.Request) (FunctionDeta
 		Schema:      lyr.Schema,
 		Name:        lyr.Function,
 		Description: lyr.Description,
+		Arguments:   make([]FunctionArgument, 0),
 		MinZoom:     viper.GetInt("DefaultMinZoom"),
 		MaxZoom:     viper.GetInt("DefaultMaxZoom"),
 	}

--- a/layer_proc_test.go
+++ b/layer_proc_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseArgDefault(t *testing.T) {
+	var tests = []struct {
+		input  string
+		output string
+	}{
+		{"foo", "foo"},
+		{"123", "123"},
+		{"'-123'::integer", "-123"},
+		{"'-123.1'::numeric", "-123.1"},
+		{"'foo'::text", "foo"},
+		{"'foo::bar'::text", "foo::bar"},
+	}
+
+	for _, test := range tests {
+		if output := parseArgDefault(test.input); output != test.output {
+			t.Error("Test Failed: {} inputted, {} expected, recieved: {}", test.input, test.output, output)
+		}
+	}
+
+}


### PR DESCRIPTION
The first commit ensures that the function layer JSON `arguments` property always contains an array (even if it's empty), which fixes a preview error for functions that don't have any arguments other than z/x/y. If there's a reason to keep using `omitempty`, I could instead adjust the preview javascript to handle when `arguments` is undefined.

The second commit is for #28 , and fixes display of default arguments with negative values.

