### PR TITLE
More intuitive CORSOrigins configuration parameter

### DIFF
--- a/config/pg_tileserv.toml.example
+++ b/config/pg_tileserv.toml.example
@@ -43,8 +43,9 @@ AssetsPath = "/usr/share/pg_tileserv/assets"
 # Advertise this maximum zoom level
 # DefaultMaxZoom = 22
 
-# Allow any page to consume these tiles
-# CORSOrigins = *
+# Allow any page to consume these tiles (default)
+# To specify domain(s) that should be CORS-allowed, express them as ["https://mydomain.com", "https://anotherdomain.org"]
+# CORSOrigins = ["*"]
 
 # Output extra logging information?
 # Debug = false

--- a/main.go
+++ b/main.go
@@ -376,8 +376,8 @@ func handleRequests() {
 	r := TileRouter()
 
 	// Allow CORS from anywhere
-	corsOrigins := viper.GetString("CORSOrigins")
-	corsOpt := handlers.AllowedOrigins([]string{corsOrigins})
+	corsOrigins := viper.GetStringSlice("CORSOrigins")
+	corsOpt := handlers.AllowedOrigins(corsOrigins)
 
 	// Set a writeTimeout for the http server.
 	// This value is the application's DbTimeout config setting plus a


### PR DESCRIPTION
- Enhance sample configuration file to allow for multiple CORS-allowed domains 
- Sample configuration file now documents default as `CORSOrigins = [ "*" ]`, a valid TOML array unlike a naked asterisk
- Use viper.GetStringSlice so that a slice of domains are passed on to Gorilla mux.
