### PR TITLE
Basic HTTPS and HTTP/2 support

### DIFF
--- a/config/pg_tileserv.toml.example
+++ b/config/pg_tileserv.toml.example
@@ -43,8 +43,9 @@ AssetsPath = "/usr/share/pg_tileserv/assets"
 # Advertise this maximum zoom level
 # DefaultMaxZoom = 22
 
-# Allow any page to consume these tiles
-# CORSOrigins = *
+# Allow any page to consume these tiles (default)
+# To specify domain(s) that should be CORS-allowed, express them as ["https://mydomain.com", "https://anotherdomain.org"]
+# CORSOrigins = ["*"]
 
 # Output extra logging information?
 # Debug = false

--- a/config/pg_tileserv.toml.example
+++ b/config/pg_tileserv.toml.example
@@ -23,6 +23,12 @@ AssetsPath = "/usr/share/pg_tileserv/assets"
 
 # Accept connections on this port
 # HttpPort = 7800
+# HttpsPort = 7801
+
+# HTTPS configuration - TLS server certificate full chain
+# TlsServerCertificateFile = ""
+# TlsServerPrivateKeyFile = ""
+
 
 # Advertise URLs relative to this server name
 # default is to look this up from incoming request headers

--- a/config/pg_tileserv.toml.example
+++ b/config/pg_tileserv.toml.example
@@ -25,7 +25,8 @@ AssetsPath = "/usr/share/pg_tileserv/assets"
 # HttpPort = 7800
 # HttpsPort = 7801
 
-# HTTPS configuration - TLS server certificate full chain
+# HTTPS configuration - TLS server certificate full chain and key
+# If you do not specify these, the TLS server will not be started
 # TlsServerCertificateFile = ""
 # TlsServerPrivateKeyFile = ""
 

--- a/main.go
+++ b/main.go
@@ -376,8 +376,8 @@ func handleRequests() {
 	r := TileRouter()
 
 	// Allow CORS from anywhere
-	corsOrigins := viper.GetString("CORSOrigins")
-	corsOpt := handlers.AllowedOrigins([]string{corsOrigins})
+	corsOrigins := viper.GetStringSlice("CORSOrigins")
+	corsOpt := handlers.AllowedOrigins(corsOrigins)
 
 	// Set a writeTimeout for the http server.
 	// This value is the application's DbTimeout config setting plus a

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -51,6 +52,9 @@ func init() {
 	viper.SetDefault("DbConnection", "sslmode=disable")
 	viper.SetDefault("HttpHost", "0.0.0.0")
 	viper.SetDefault("HttpPort", 7800)
+	viper.SetDefault("HttpsPort", 7801)
+	viper.SetDefault("TlsServerCertificateFile", "")
+	viper.SetDefault("TlsServerPrivateKeyFile", "")
 	viper.SetDefault("UrlBase", "")
 	viper.SetDefault("DefaultResolution", 4096)
 	viper.SetDefault("DefaultBuffer", 256)
@@ -110,7 +114,8 @@ func main() {
 		log.Info("Using database connection info from environment variable DATABASE_URL")
 	}
 
-	log.Infof("Serving at %s:%d", viper.GetString("HttpHost"), viper.GetInt("HttpPort"))
+	log.Infof("Serving HTTP  at %s:%d", viper.GetString("HttpHost"), viper.GetInt("HttpPort"))
+	log.Infof("Serving HTTPS at %s:%d", viper.GetString("HttpsHost"), viper.GetInt("HttpsPort"))
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
@@ -405,6 +410,36 @@ func handleRequests() {
 		}
 	}()
 
+	tlsServerCert := viper.GetString("TlsServerCertificateFile")
+	tlsServerPrivKey := viper.GetString("TlsServerPrivateKeyFile")
+	var stls *http.Server
+	doServeTLS := false
+	// Attempt to use HTTPS only if server certificate and private key files specified
+	if tlsServerCert != "" && tlsServerPrivKey != "" {
+		doServeTLS = true
+	}
+
+	if doServeTLS {
+		stls = &http.Server{
+			ReadTimeout:  1 * time.Second,
+			WriteTimeout: writeTimeout,
+			Addr:         fmt.Sprintf("%s:%d", viper.GetString("HttpHost"), viper.GetInt("HttpsPort")),
+			Handler:      handlers.CompressHandler(handlers.CORS(corsOpt)(r)),
+			TLSConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12, // Secure TLS versions only
+			},
+		}
+
+		// start https service
+		go func() {
+			// ListenAndServe returns http.ErrServerClosed when the server receives
+			// a call to Shutdown(). Other errors are unexpected.
+			if err := stls.ListenAndServeTLS(tlsServerCert, tlsServerPrivKey); err != nil && err != http.ErrServerClosed {
+				log.Fatal(err)
+			}
+		}()
+	}
+
 	// wait here for interrupt signal
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, os.Interrupt)
@@ -416,6 +451,9 @@ func handleRequests() {
 	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
 	defer cancel()
 	s.Shutdown(ctx)
+	if doServeTLS {
+		stls.Shutdown(ctx)
+	}
 
 	if globalDb != nil {
 		log.Debugln("Closing DB connections")

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 	}
 
 	log.Infof("Serving HTTP  at %s:%d", viper.GetString("HttpHost"), viper.GetInt("HttpPort"))
-	log.Infof("Serving HTTPS at %s:%d", viper.GetString("HttpsHost"), viper.GetInt("HttpsPort"))
+	log.Infof("Serving HTTPS at %s:%d", viper.GetString("HttpHost"), viper.GetInt("HttpsPort"))
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {


### PR DESCRIPTION
Fixes #7.
- Add configuration parameters to allow call to `ListenAndServeTLS`
- Verified that HTTP/2 works when connecting to `pg_tileserv` in TLS mode via CaddyServer (`proxy` mode with `insecureskipverify` to the default HTTPS port 7801) and using `curl -k` .
- HTTP/2 request multiplexing should now work helping with tile delivery throughput in production setups