### PR TITLE
Fix: Use UrlBase in index.html

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -23,7 +23,7 @@
   {{ range $key, $value := . }}
   {{ if eq $value.Type "table" }}
   <li>
-    <strong class="layer-name">{{ $value.Id }}</strong> (<a href="{{ $value.Id }}.html">preview</a> | <a href="{{ $value.Id }}.json">json</a>)
+    <strong class="layer-name">{{ $value.Id }}</strong> (<a href='{{ $value.DetailUrl | replace ".json" ".html"}}'>preview</a> | <a href="{{ $value.DetailUrl }}">json</a>)
     {{ if $value.Description }}<br/><span class="layer-description">{{ $value.Description }}</span> {{ end }}
   </li>
   {{ end }}
@@ -35,7 +35,7 @@
   {{ range $key, $value := . }}
   {{ if eq $value.Type "function" }}
   <li>
-    <strong class="layer-name">{{ $value.Id }}</strong> (<a href="{{ $value.Id }}.html">preview</a> | <a href="{{ $value.Id }}.json">json</a>)
+    <strong class="layer-name">{{ $value.Id }}</strong> (<a href='{{$value.DetailUrl | replace ".json" ".html"}}'>preview</a> | <a href="{{ $value.DetailUrl }}">json</a>)
     {{ if $value.Description }}<br/><span class="layer-description">{{ $value.Description }}</span> {{ end }}
   </li>
   {{ end }}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"time"
+	"io/ioutil"
 
 	// REST routing
 	"github.com/gorilla/handlers"
@@ -25,6 +26,9 @@ import (
 	// Configuration
 	"github.com/pborman/getopt/v2"
 	"github.com/spf13/viper"
+
+	// Template functions
+	"github.com/Masterminds/sprig/v3"
 )
 
 // programName is the name string we use
@@ -218,7 +222,15 @@ func requestListHtml(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 	jsonLayers := GetJsonLayers(r)
-	t, err := template.ParseFiles(fmt.Sprintf("%s/index.html", viper.GetString("AssetsPath")))
+
+	content, err := ioutil.ReadFile(fmt.Sprintf("%s/index.html", viper.GetString("AssetsPath")))
+
+	if err != nil {
+		return err
+	}
+
+	t, err := template.New("index").Funcs(sprig.FuncMap()).Parse(string(content))
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If *UrlBase* is set in config file, the links generated in index.html are wrong. 

This PR tries to fix it.

NB: as i'm not familiar with golang, i'm not sure about the `go.sum` and `go.mod`
generated, i let these changes in a separate commit. I've used golang `1.13`