### PR TITLE
option to mount the service at a specified path

### DIFF
--- a/config/pg_tileserv.toml.example
+++ b/config/pg_tileserv.toml.example
@@ -16,7 +16,7 @@
 # DbTimeout = 10
 
 # Look to read html templates from this directory
-AssetsPath = "/usr/share/pg_tileserv/assets"
+# AssetsPath = "/usr/share/pg_tileserv/assets"
 
 # Accept connections on this subnet (default accepts on all)
 # HttpHost = "0.0.0.0"
@@ -34,6 +34,10 @@ AssetsPath = "/usr/share/pg_tileserv/assets"
 # Advertise URLs relative to this server name
 # default is to look this up from incoming request headers
 # UrlBase = "http://localhost/"
+
+# Optional path to add to the service base URL
+# If set, all routes will be prefixed with this path
+# BasePath = "/"
 
 # Resolution to quantize vector tiles to
 # DefaultResolution = 4096

--- a/main.go
+++ b/main.go
@@ -120,9 +120,6 @@ func main() {
 		log.Info("Using database connection info from environment variable DATABASE_URL")
 	}
 
-	log.Infof("Serving HTTP  at %s:%d", viper.GetString("HttpHost"), viper.GetInt("HttpPort"))
-	log.Infof("Serving HTTPS at %s:%d", viper.GetString("HttpHost"), viper.GetInt("HttpsPort"))
-
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			log.Debugf("viper.ConfigFileNotFoundError: %s", err)
@@ -142,6 +139,12 @@ func main() {
 			log.Info("Config file: none found, using defaults")
 		}
 	}
+
+	basePath := viper.GetString("BasePath")
+	log.Infof("Serving HTTP  at %s/", formatBaseURL(fmt.Sprintf("http://%s:%d",
+		viper.GetString("HttpHost"), viper.GetInt("HttpPort")), basePath))
+	log.Infof("Serving HTTPS at %s/", formatBaseURL(fmt.Sprintf("http://%s:%d",
+		viper.GetString("HttpHost"), viper.GetInt("HttpsPort")), basePath))
 
 	// Load the global layer list right away
 	// Also connects to database

--- a/main.go
+++ b/main.go
@@ -7,11 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
-	"io/ioutil"
 
 	// REST routing
 	"github.com/gorilla/handlers"
@@ -72,6 +73,7 @@ func init() {
 	viper.SetDefault("DbPoolMaxConns", 4)
 	viper.SetDefault("DbTimeout", 10)
 	viper.SetDefault("CORSOrigins", "*")
+	viper.SetDefault("BasePath", "/")
 }
 
 func main() {
@@ -374,7 +376,14 @@ func (fn tileAppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func TileRouter() *mux.Router {
 	// creates a new instance of a mux router
-	r := mux.NewRouter().StrictSlash(true)
+	r := mux.NewRouter().
+		StrictSlash(true).
+		PathPrefix(
+			"/" +
+				strings.TrimLeft(viper.GetString("BasePath"), "/"),
+		).
+		Subrouter()
+
 	// Front page and layer list
 	r.Handle("/", tileAppHandler(requestListHtml))
 	r.Handle("/index.html", tileAppHandler(requestListHtml))

--- a/main_test.go
+++ b/main_test.go
@@ -49,18 +49,24 @@ func TestDBNoTables(t *testing.T) {
 	assert.Equal(t, json_expect, json_result, "empty json response is expected")
 }
 
+// TestBasePath sets an alternate base path to check that handlers are
+// mounted at the specified path
 func TestBasePath(t *testing.T) {
+
 	if !dbsetup {
 		t.Skip("DB integration test suite setup failed, skipping")
 	}
 
-	// set an alternate base path to check that handlers are
-	// mounted at the specified path
-	viper.Set("BasePath", "/test")
+	// paths to check
+	paths := []string{"/test", "/test/"}
 
-	r := TileRouter()
-	request, _ := http.NewRequest("GET", "/test/index.json", nil)
-	response := httptest.NewRecorder()
-	r.ServeHTTP(response, request)
-	assert.Equal(t, 200, response.Code, "OK response is expected")
+	for _, path := range paths {
+		viper.Set("BasePath", path)
+		r := TileRouter()
+		request, _ := http.NewRequest("GET", "/test/index.json", nil)
+		response := httptest.NewRecorder()
+		r.ServeHTTP(response, request)
+		assert.Equal(t, 200, response.Code, "OK response is expected")
+	}
+
 }

--- a/main_test.go
+++ b/main_test.go
@@ -48,3 +48,19 @@ func TestDBNoTables(t *testing.T) {
 	json_expect := "{}"
 	assert.Equal(t, json_expect, json_result, "empty json response is expected")
 }
+
+func TestBasePath(t *testing.T) {
+	if !dbsetup {
+		t.Skip("DB integration test suite setup failed, skipping")
+	}
+
+	// set an alternate base path to check that handlers are
+	// mounted at the specified path
+	viper.Set("BasePath", "/test")
+
+	r := TileRouter()
+	request, _ := http.NewRequest("GET", "/test/index.json", nil)
+	response := httptest.NewRecorder()
+	r.ServeHTTP(response, request)
+	assert.Equal(t, 200, response.Code, "OK response is expected")
+}

--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"text/template"
 
@@ -13,14 +14,44 @@ import (
 	// log "github.com/sirupsen/logrus"
 )
 
-// serverURLBase returns the server URL
+// formatBaseURL takes a hostname (baseHost) and a base path
+// and joins them.  Both are parsed as URLs (using net/url) and
+// then joined to ensure a properly formed URL.
+// net/url does not support parsing hostnames without a scheme
+// (e.g. example.com is invalid; http://example.com is valid).
+// serverURLHost ensures a scheme is added.
+func formatBaseURL(baseHost string, basePath string) string {
+	urlHost, err := url.Parse(baseHost)
+	if err != nil {
+		log.Fatal(err)
+	}
+	urlPath, err := url.Parse(basePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return strings.TrimRight(urlHost.ResolveReference(urlPath).String(), "/")
+}
+
+// serverURLBase returns the base server URL
 // that the client used to access this service.
+// All pg_tileserv routes are mounted relative to
+// this URL (including path, if specified by the
+// BasePath config option)
+func serverURLBase(r *http.Request) string {
+	baseHost := serverURLHost(r)
+	basePath := viper.GetString("BasePath")
+
+	return formatBaseURL(baseHost, basePath)
+}
+
+// serverURLHost returns the host (and scheme)
+// for this service.
 // In the case of access via a proxy service, if
 // the standard headers are set, we return that
-// URL base. If necessary the automatic calculation
+// hostname. If necessary the automatic calculation
 // can be over-ridden by setting the "UrlBase"
-// configuration option
-func serverURLBase(r *http.Request) string {
+// configuration option.
+func serverURLHost(r *http.Request) string {
 	// Use configuration file settings if we have them
 	configUrl := viper.GetString("UrlBase")
 	if configUrl != "" {

--- a/util_test.go
+++ b/util_test.go
@@ -18,7 +18,7 @@ func Test_formatBaseURL(t *testing.T) {
 			"http://example.com/tiles",
 		},
 		{
-			[]string{"http://example.com/", "/tiles"},
+			[]string{"http://example.com/", "/tiles/"},
 			"http://example.com/tiles",
 		},
 		{

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test_formatBaseURL(t *testing.T) {
+	var tests = []struct {
+		input  []string
+		output string
+	}{
+		{
+			[]string{"http://example.com", "/tiles"},
+			"http://example.com/tiles",
+		},
+		{
+			[]string{"http://example.com", "tiles"},
+			"http://example.com/tiles",
+		},
+		{
+			[]string{"http://example.com/", "/tiles"},
+			"http://example.com/tiles",
+		},
+		{
+			[]string{"https://example.com/", "/"},
+			"https://example.com",
+		},
+	}
+
+	for _, test := range tests {
+		if output := formatBaseURL(test.input[0], test.input[1]); output != test.output {
+			t.Errorf("Test failed: input: %v, expected: %s, recieved: %s", test.input, test.output, output)
+		}
+	}
+}


### PR DESCRIPTION
New feature for #54 - a config option ("BasePath") to specify a base path to mount the service at.  For example, specifying `BasePath = /tiles` would result in URLs like `http://example.com/tiles/public.wells.json`. This is a requirement for us too (we've been using nginx path rewriting to work around it).

This uses the `net/url` library to ensure that user supplied paths are tacked onto the hostname properly. One issue I would point out is it *might* be possible for users to already be using a UrlBase value that `url.Parse` doesn't like (for example, `UrlBase = localhost` without the http:// on the front). If this PR needs to handle that I can make that work.