### PR TITLE
feat(makefile): add docker buildx support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
+include cnf.mak.docker
 
-APPVERSION := latest
 GOVERSION := 1.15
 PROGRAM := pg_tileserv
-CONTAINER := pramsey/$(PROGRAM)
+CONTAINER := $(REPO)/$(PROGRAM)
 
 RM = /bin/rm
 CP = /bin/cp
@@ -36,6 +36,9 @@ bin-docker:  ##    Build a local binary based off of a golang base docker image
 
 build-docker: $(PROGRAM) Dockerfile  ##  Generate a CentOS 7 container with APPVERSION tag, using binary from current environment
 	docker build -f Dockerfile --build-arg VERSION=$(APPVERSION) -t $(CONTAINER):$(APPVERSION) .
+
+buildx-docker:	## Compiles multi-arch images and pushes them to a custom repository
+	docker buildx build --platform $(ARCH) -t $(CONTAINER):$(APPVERSION) --push .
 
 release: clean docs build build-docker  ##       Generate the docs, a local build, and then uses the local build to generate a CentOS 7 container
 

--- a/cnf.mak.docker
+++ b/cnf.mak.docker
@@ -1,0 +1,28 @@
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo not')
+
+ifeq ($(uname_M),x86_64)
+    ARCH=amd64
+endif
+
+ifeq ($(uname_S),Linux)
+    ARCH=$(shell sh -c 'dpkg --print-architecture 2>/dev/null || echo not')
+endif
+
+TARGET_GOAL := $(firstword $(subst " ", ,$(wordlist 1,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))))
+
+REPO := $(firstword $(subst " ", ,$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))))
+$(eval $(REPO):;@:)
+ifeq ($(REPO),)
+    REPO=pramsey
+endif
+
+APPVERSION := $(firstword $(subst " ", ,$(wordlist 3,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))))
+$(eval $(APPVERSION):;@:)
+ifeq ($(APPVERSION),)
+    APPVERSION=latest
+endif
+
+ifeq ($(TARGET_GOAL),buildx-docker)
+    ARCH=linux/amd64,linux/arm64
+endif


### PR DESCRIPTION
Assumes that `docker buildx` has been setup on the developer's machine.

**cnf.mak.docker**

Introduces some logic to determine the arch and docker options and leave current Makefile behavior intact

**Makefile**

Add `buildx-docker` that will compile multi-arch images. On MacOS, it took me about 2 minutes--pretty fast!

**Examples**
- `make buildx-docker` will push directly to the [official image](https://hub.docker.com/r/pramsey/pg_tileserv)
- `make buildx-docker USERNAME_OR_REGISTRY TAG`

**Update**
Fixed argument parsing for APPVERSION