### PR TITLE
multi-arch docker image support

### DIFF
--- a/.cnf.makefile
+++ b/.cnf.makefile
@@ -1,0 +1,20 @@
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo ""')
+uname_M := $(shell sh -c 'uname -m 2>/dev/null || echo ""')
+
+ifeq ($(uname_M),x86_64)
+    ARCH=amd64
+endif
+
+ifeq ($(uname_S),Linux)
+    ARCH=$(shell sh -c 'dpkg --print-architecture 2>/dev/null || echo not')
+endif
+
+DOCKERFILE := Dockerfile
+APPVERSION := latest
+REPO := pramsey
+TARGET_GOAL := $(firstword $(subst " ", ,$(wordlist 1,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))))
+BUILDPLATFORM := linux/amd64,linux/arm64
+
+ifeq ($(DOCKERFILE),Dockerfile.alpine)
+    APPVERSION := $(APPVERSION)-alpine-3.12
+endif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
+# Lightweight Alpine-based pg_tileserv Docker Image
+# Author: Just van den Broecke
+FROM golang:1.15.5
+
+# Build ARGS
+ARG VERSION
+
+RUN mkdir /app
+ADD . /app/
+WORKDIR /app
+RUN go build -v -ldflags "-s -w -X main.programVersion=${VERSION}" \
+    && chmod +x ./pg_tileserv
+
 # copy build result to a centos base image to match other
 # crunchy containers
 FROM centos:7
 RUN mkdir /app
-ADD ./pg_tileserv /app/
-ADD ./assets /app/assets
-
-ARG VERSION
+COPY --from=0 /app/assets /app/assets
+COPY --from=0 /app/pg_tileserv /app/pg_tileserv
 
 LABEL vendor="Crunchy Data" \
 	url="https://crunchydata.com" \

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
+include .cnf.makefile
 
-APPVERSION := latest
 GOVERSION := 1.15
 PROGRAM := pg_tileserv
-CONTAINER := pramsey/$(PROGRAM)
 
 RM = /bin/rm
 CP = /bin/cp
 MKDIR = /bin/mkdir
 
-.PHONY: bin-docker build-docker build check clean docs install release test uninstall
+.PHONY: bin-docker build-docker buildx-docker build check clean docs install install-buildx release test uninstall
 
 .DEFAULT_GOAL := help
 
@@ -16,33 +15,36 @@ GOFILES := $(wildcard *.go)
 
 all: $(PROGRAM)
 
-check:  ##         This checks the current version of Go installed locally
+check:  ##          This checks the current version of Go installed locally
 	@go version
 
-clean:  ##         This will clean all local build artifacts
+clean:  ##          This will clean all local build artifacts
 	$(info Cleaning project...)
 	@rm -f $(PROGRAM)
 	@rm -rf docs/*
 	docker image prune --force
 
-docs:   ##          Generate docs
+docs:   ##           Generate docs
 	@rm -rf docs/* && cd hugo && hugo && cd ..
 
-build: $(GOFILES)  ##         Build a local binary using APPVERSION parameter or CI as default
+build: $(GOFILES)  ##          Build a local binary using APPVERSION parameter or CI as default
 	go build -v -ldflags "-s -w -X main.programVersion=$(APPVERSION)"
 
-bin-docker:  ##    Build a local binary based off of a golang base docker image
+bin-docker:  ##     Build a local binary based off of a golang base docker image
 	sudo docker run --rm -v "$(PWD)":/usr/src/myapp:z -w /usr/src/myapp golang:$(GOVERSION) make APPVERSION=$(APPVERSION) build
 
-build-docker: $(PROGRAM) Dockerfile  ##  Generate a CentOS 7 container with APPVERSION tag, using binary from current environment
-	docker build -f Dockerfile --build-arg VERSION=$(APPVERSION) -t $(CONTAINER):$(APPVERSION) .
+build-docker: $(PROGRAM) Dockerfile  ##   Generate a CentOS 7 container with APPVERSION tag, using binary from current environment
+	docker build -f $(DOCKERFILE) --build-arg VERSION=$(APPVERSION) -t $(REPO)/$(PROGRAM):$(APPVERSION) .
 
-release: clean docs build build-docker  ##       Generate the docs, a local build, and then uses the local build to generate a CentOS 7 container
+buildx-docker:	##  Compiles multi-arch images and pushes them to a custom repository
+	docker buildx build -f $(DOCKERFILE) --platform=$(BUILDPLATFORM) --build-arg VERSION=$(APPVERSION) -t $(REPO)/$(PROGRAM):$(APPVERSION) --push .
 
-test:  ##          Run the tests locally
+release: clean docs build build-docker  ##        Generate the docs, a local build, and then uses the local build to generate a CentOS 7 container
+
+test:  ##           Run the tests locally
 	go test -v
 
-install: $(PROGRAM) docs  ##       This will install the program locally
+install: $(PROGRAM) docs  ##        This will install the program locally
 	$(MKDIR) -p $(DESTDIR)/usr/bin
 	$(MKDIR) -p $(DESTDIR)/usr/share/$(PROGRAM)
 	$(MKDIR) -p $(DESTDIR)/etc
@@ -51,12 +53,16 @@ install: $(PROGRAM) docs  ##       This will install the program locally
 	$(CP) -r assets $(DESTDIR)/usr/share/$(PROGRAM)/assets
 	$(CP) -r docs $(DESTDIR)/usr/share/$(PROGRAM)/docs
 
-uninstall:  ##     This will uninstall the program from your local system
+install-buildx:	## This will install the buildx plugin for docker depending on the system
+	wget -nc --quiet https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.$(uname_S)-$(ARCH) -P ~/.docker/cli-plugins -O docker-buildx
+	chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+uninstall:  ##      This will uninstall the program from your local system
 	$(RM) $(DESTDIR)/usr/bin/$(PROGRAM)
 	$(RM) $(DESTDIR)/etc/$(PROGRAM).toml
 	$(RM) -r $(DESTDIR)/usr/share/$(PROGRAM)
 
-help:   ##          Prints this help message
+help:   ##           Prints this help message
 	@echo ""
 	@echo ""
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/:.*##/:/'


### PR DESCRIPTION
#### Update
My first PR #69 had issues, sorry about that.

I took some more time to work those problems out and made sure the `buildx` addition works and makes sense.

I also realized the anti-pattern of treating multi-targets as "arguments", so I removed this. Hopefully the following contribution is the right scope.

---

~Assumes that `docker buildx` has been setup on the developer's machine.~ (now a Makefile target)

**.cnf.makefile**

Defines environment variables that are important to docker and some logic to determine the cpu arch and leaves current Makefile behavior intact.

**Dockerfile**
Added build stage from `Dockerfile.alpine` so that multi-arch support is guaranteed for centos build

**Makefile**

- Adds `make install-buildx`, will follow the steps described at the official [docker/buildx](https://github.com/docker/buildx) repository.
- Adds `make buildx-docker` that will compile (and push) multi-arch images.

- Adds environment vars:

|Name|Default|Description|Purpose|
|---|---|---|---|
|**ARCH**|-|CPU architecture|facilitates downloading in `make install-buildx`|
|**uname_S**|-|output from `uname -s`|determines `ARCH`|
|**uname_M**|-|output from `uname -m`|determines `ARCH`|
|**TARGET_GOAL**|(implicit)|will always be the make target|logic for whether to use `docker buildx`|
|**DOCKERFILE**|`Dockerfile`|which Dockerfile to use|allows the Dockerfile.alpine selection|
|**BUILDPLATFORM**|`linux/amd64,linux/arm64`|which architectures to build|for multi-arch builds|
|**REPO**|`pramsey`|docker username or repo|allows publishing to alternative places (e.g. `awill88`)|

**Installing buildx**
`make install-buildx`

**Pushing Images (same deal as before)**
- `make buildx-docker` will push directly to the [official image](https://hub.docker.com/r/pramsey/pg_tileserv) using the default Dockerfile
- `make DOCKERFILE=Dockerfile.alpine buildx-docker` will push directly to the [official image](https://hub.docker.com/r/pramsey/pg_tileserv) and tag it for alpine

*Tested on macOS Big Sur (Docker Engine v20.10)*
