### PR TITLE
Docs: fix missing start of config comment in example config in installation instructions

### DIFF
--- a/hugo/content/installation/_index.md
+++ b/hugo/content/installation/_index.md
@@ -136,6 +136,6 @@ DefaultMinZoom = 0
 DefaultMaxZoom = 22
 # Allow any page to consume these tiles
 CORSOrigins = *
-tra logging information?
+# Output extra logging information?
 Debug = false
 ```


### PR DESCRIPTION
This commit adds the missing comment markup and makes the comment match similar configs in the code base, like e.g. `README.md` or `config/pg_tileserv.toml.example`. I noticed the missing hash character and missing words in the [official docs](https://access.crunchydata.com/documentation/pg_tileserv/latest/installation/) and assume this is the code that needs to be changed to fix this.