### PR TITLE
Add style for default layer in function preview

### DIFF
--- a/assets/preview-function.html
+++ b/assets/preview-function.html
@@ -154,7 +154,9 @@
         return {
           "id": layerId(id, gtype, paint),
           "source": id,
-          "source-layer": id,
+          // function layers implementor will decide of an arbitrary layer name inside the tile.
+          // most often, they will keep the name "default" as it is st_asmvt default value for this parameter.
+          "source-layer": "default",
           "type": paint,
           "paint": paints[paint],
           "filter": ["match", ["geometry-type"], [gtype, "Multi"+gtype], true, false]


### PR DESCRIPTION
This is a partial fix https://github.com/CrunchyData/pg_tileserv/issues/134, covering most needs.

Actually, by default `st_asmvt` puts every geom in the same layer named `default`, but only style for the fully qualified function name were added. 

This MR intents to cover the most common case by actually setting styles for the 'default' layer inside the MVT. For other more complicated cases (other layer name, several layer in the same MVT), let's hope people will configure their viewer correctly? 

This breaks the preview for functions that does set the layer name to the fully qualified function name, so if this changes is agreed upon, I will update the example in the documentation to use the default layer name.

