### PR TITLE
Add link to toml example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To get more information about what is going on behind the scenes, run with the `
 
 ## Configuration File
 
-The configuration file will be automatically read from the following locations, if it exists:
+The [configuration file](config/pg_tileserv.toml.example) will be automatically read from the following locations, if it exists:
 
 * In the system configuration directory, at `/etc/pg_tileserv.toml`
 * Relative to the directory from which the program is run, `./config/pg_tileserv.toml`


### PR DESCRIPTION
Just a quick update to add link to toml example file so I don't have to search for it every time and as part of the effort to merge the docs and options for tileserv and featureserv.