### PR TITLE
docs: fix config reading sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ To get more information about what is going on behind the scenes, run with the `
 
 The [configuration file](config/pg_tileserv.toml.example) will be automatically read from the following locations, if it exists:
 
-* In the system configuration directory, at `/etc/pg_tileserv.toml`
 * Relative to the directory from which the program is run, `./config/pg_tileserv.toml`
 * In a root volume at `/config/pg_tileserv.toml`
+* In the system configuration directory, at `/etc/pg_tileserv.toml`
 
 If you want to pass a path directly to the configuration file, use the `--config` commandline parameter to pass in a pull path to configuration file. When using the `--config` option, configuration files in other locations will be ignored.
 

--- a/hugo/content/installation/_index.md
+++ b/hugo/content/installation/_index.md
@@ -95,8 +95,9 @@ pg_tileserv.exe
 
 The configuration file will be automatically read from the following locations, if it exists:
 
+* Relative to the directory from which the program is run, `./config/pg_tileserv.toml`
+* In a root volume at `/config/pg_tileserv.toml`
 * In the system configuration directory, at `/etc/pg_tileserv.toml`
-* Relative to the directory from which the program is run, `./pg_tileserv.toml`
 
 If you want to pass a path directly to the configuration file, use the `--config` command line parameter.
 


### PR DESCRIPTION
1. Default config file searching paths are `./config/pg_tileserv.toml`, `/config/pg_tileserv.toml`, `/etc/pg_tileserv.toml`. They are searched  by sequence.
2. The description of the default config file are inconsistent in README and docs.
