### PR TITLE
Retain mutex while iterating over globalLayers

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -97,6 +97,7 @@ type layerJSON struct {
 func getJSONLayers(r *http.Request) map[string]layerJSON {
 	json := make(map[string]layerJSON)
 	urlBase := serverURLBase(r)
+	globalLayersMutex.Lock()
 	for k, v := range globalLayers {
 		json[k] = layerJSON{
 			Type:        v.GetType().String(),
@@ -107,5 +108,6 @@ func getJSONLayers(r *http.Request) map[string]layerJSON {
 			DetailURL:   fmt.Sprintf("%s/%s.json", urlBase, url.PathEscape(v.GetID())),
 		}
 	}
+	globalLayersMutex.Unlock()
 	return json
 }


### PR DESCRIPTION
Following up on #145: We'd been getting "concurrent map iteration and map write" panics at this range over `globalLayers`; and, as in #89, acquiring the mutex around this operation seems to have put an end to the errors.