### PR TITLE
Update setup go to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: 'Install Go'
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.17.x
 


### PR DESCRIPTION
In Github actions, we see a warning of node version deprecation. it states that node v12 will not be used further, so we need to update to node 16 at least. this PR encompasses the changes of setup-go action to the newest version. It's simple and it works