### PR TITLE
Fixed a broken link in the examples page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ public/
 config/pg_tileserv*.toml
 server.crt
 server.key
+hugo/.hugo_build.lock

--- a/hugo/content/examples/example-mapbox-gl-js.md
+++ b/hugo/content/examples/example-mapbox-gl-js.md
@@ -7,6 +7,6 @@ weight: 300
 
 This example demonstrates interactivity where clicking within a boundary displays a popup that shows feature properties. The web preview for `pg_tileserv` also uses Mapbox GL JS.
 
-With the service running, open the [HTML]((https://github.com/CrunchyData/pg_tileserv/blob/master/examples/mapbox-gl-js/mapbox-gl-js-tiles.html)) in your browser.
+With the service running, open the [HTML](https://github.com/CrunchyData/pg_tileserv/blob/master/examples/mapbox-gl-js/mapbox-gl-js-tiles.html) in your browser.
 
 ![Mapbox GL JS map preview](/example-mapbox.png)


### PR DESCRIPTION
This is a tiny issue, but I figured I could get started with something easy that happened to cause a little friction earlier today.