### PR TITLE
Applied `gofmt` and most of `go lint`'s suggestions

### DIFF
--- a/cql/cql.go
+++ b/cql/cql.go
@@ -77,7 +77,7 @@ func syntaxErrorMsg(input string, col int) string {
 	return msg
 }
 
-//======================================
+// ======================================
 type CqlErrorListener struct {
 	*antlr.DefaultErrorListener
 	errorCount int
@@ -162,7 +162,7 @@ func getNodeText(node antlr.TerminalNode) string {
 	return node.GetText()
 }
 
-//========================================
+// ========================================
 type CqlContext struct {
 	*antlr.BaseParserRuleContext
 	// SQL fragment for the context subtree

--- a/cql/cqlparser_base_listener.go
+++ b/cql/cqlparser_base_listener.go
@@ -61,7 +61,8 @@ func (s *BaseCQLParserListener) EnterBinaryComparisonPredicate(ctx *BinaryCompar
 }
 
 // ExitBinaryComparisonPredicate is called when production binaryComparisonPredicate is exited.
-func (s *BaseCQLParserListener) ExitBinaryComparisonPredicate(ctx *BinaryComparisonPredicateContext) {}
+func (s *BaseCQLParserListener) ExitBinaryComparisonPredicate(ctx *BinaryComparisonPredicateContext) {
+}
 
 // EnterLikePredicate is called when production likePredicate is entered.
 func (s *BaseCQLParserListener) EnterLikePredicate(ctx *LikePredicateContext) {}

--- a/layer.go
+++ b/layer.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 
 	"net/http"
@@ -43,6 +42,7 @@ type Layer interface {
 	WriteLayerJSON(w http.ResponseWriter, req *http.Request) error
 }
 
+// A TileRequest specifies what to fetch from the database for a single tile
 type TileRequest struct {
 	LayerID string
 	Tile    Tile
@@ -55,7 +55,7 @@ func getLayer(lyrID string) (Layer, error) {
 	if ok {
 		return lyr, nil
 	}
-	return lyr, errors.New(fmt.Sprintf("Unable to get layer '%s'", lyrID))
+	return lyr, fmt.Errorf("Unable to get layer '%s'", lyrID)
 }
 
 func loadLayers() error {

--- a/layer_proc.go
+++ b/layer_proc.go
@@ -54,26 +54,34 @@ type FunctionDetailJSON struct {
  * Layer Interface
  */
 
+// GetType disambiguates between function and table layers
 func (lyr LayerFunction) GetType() LayerType {
 	return LayerTypeFunction
 }
 
+// GetID returns the complete ID (schema.name) by which to reference a given layer
 func (lyr LayerFunction) GetID() string {
 	return lyr.ID
 }
 
+// GetDescription returns the text description for a layer
+// or an empty string if no description is set
 func (lyr LayerFunction) GetDescription() string {
 	return lyr.Description
 }
 
+// GetName returns just the name of a given layer
 func (lyr LayerFunction) GetName() string {
 	return lyr.Function
 }
 
+// GetSchema returns just the schema for a given layer
 func (lyr LayerFunction) GetSchema() string {
 	return lyr.Schema
 }
 
+// GetTileRequest takes tile and request parameters as input and returns a TileRequest
+// specifying the SQL and any additional arguments to fetch appropriate data
 func (lyr LayerFunction) GetTileRequest(tile Tile, r *http.Request) TileRequest {
 
 	procArgs := lyr.getFunctionArgs(r.URL.Query())
@@ -88,6 +96,7 @@ func (lyr LayerFunction) GetTileRequest(tile Tile, r *http.Request) TileRequest 
 	return tr
 }
 
+// WriteLayerJSON outputs parameters and optional arguments for the function layer
 func (lyr LayerFunction) WriteLayerJSON(w http.ResponseWriter, req *http.Request) error {
 	jsonTableDetail, err := lyr.getFunctionDetailJSON(req)
 	if err != nil {

--- a/layer_table.go
+++ b/layer_table.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// LayerTable provides metadata about the table layer
 type LayerTable struct {
 	ID             string
 	Schema         string
@@ -33,6 +34,8 @@ type LayerTable struct {
 	Srid           int
 }
 
+// TableProperty provides metadata about a single property field,
+// features in a table layer may have multiple such fields
 type TableProperty struct {
 	Name        string `json:"name"`
 	Type        string `json:"type"`
@@ -40,6 +43,7 @@ type TableProperty struct {
 	order       int
 }
 
+// TableDetailJSON gives the output structure for the table layer.
 type TableDetailJSON struct {
 	ID           string          `json:"id"`
 	Schema       string          `json:"schema"`
@@ -58,26 +62,33 @@ type TableDetailJSON struct {
  * Layer Interface
  */
 
+// GetType disambiguates between function and table layers
 func (lyr LayerTable) GetType() LayerType {
 	return LayerTypeTable
 }
 
+// GetID returns the complete ID (schema.name) by which to reference a given layer
 func (lyr LayerTable) GetID() string {
 	return lyr.ID
 }
 
+// GetDescription returns the text description for a layer
+// or an empty string if no description is set
 func (lyr LayerTable) GetDescription() string {
 	return lyr.Description
 }
 
+// GetName returns just the name of a given layer
 func (lyr LayerTable) GetName() string {
 	return lyr.Table
 }
 
+// GetSchema returns just the schema for a given layer
 func (lyr LayerTable) GetSchema() string {
 	return lyr.Schema
 }
 
+// WriteLayerJSON outputs parameters and optional arguments for the table layer
 func (lyr LayerTable) WriteLayerJSON(w http.ResponseWriter, req *http.Request) error {
 	jsonTableDetail, err := lyr.getTableDetailJSON(req)
 	if err != nil {
@@ -89,6 +100,8 @@ func (lyr LayerTable) WriteLayerJSON(w http.ResponseWriter, req *http.Request) e
 	return nil
 }
 
+// GetTileRequest takes tile and request parameters as input and returns a TileRequest
+// specifying the SQL to fetch appropriate data
 func (lyr LayerTable) GetTileRequest(tile Tile, r *http.Request) TileRequest {
 	rp := lyr.getQueryParameters(r.URL.Query())
 	sql, _ := lyr.requestSQL(&tile, &rp)
@@ -262,6 +275,8 @@ func (lyr *LayerTable) getTableDetailJSON(req *http.Request) (TableDetailJSON, e
 	return td, nil
 }
 
+// GetBoundsExact returns the data coverage extent for a table layer
+// in EPSG:4326, clipped to (+/-180, +/-90)
 func (lyr *LayerTable) GetBoundsExact() (Bounds, error) {
 	bounds := Bounds{}
 	extentSQL := fmt.Sprintf(`
@@ -308,6 +323,7 @@ func (lyr *LayerTable) GetBoundsExact() (Bounds, error) {
 	return bounds, nil
 }
 
+// GetBounds returns the estimated extent for a table layer, transformed to EPSG:4326
 func (lyr *LayerTable) GetBounds() (Bounds, error) {
 	bounds := Bounds{}
 	extentSQL := fmt.Sprintf(`

--- a/main.go
+++ b/main.go
@@ -44,17 +44,17 @@ const programName string = "pg_tileserv"
 var programVersion string
 
 // globalDb is a global database connection pointer
-var globalDb *pgxpool.Pool = nil
+var globalDb *pgxpool.Pool
 
 // globalVersions holds the parsed output of postgis_full_version()
-var globalVersions map[string]string = nil
+var globalVersions map[string]string
 
 // globalPostGISVersion is numeric, sortable postgis version (3.2.1 => 3002001)
-var globalPostGISVersion int = 0
+var globalPostGISVersion int
 
 // serverBounds are the coordinate reference system and extent from
 // which tiles are constructed
-var globalServerBounds *Bounds = nil
+var globalServerBounds *Bounds
 
 // timeToLive is the Cache-Control timeout value that will be advertised
 // in the response headers

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ import (
 const programName string = "pg_tileserv"
 
 // programVersion is the version string we use
-//const programVersion string = "0.1"
+// const programVersion string = "0.1"
 var programVersion string
 
 // globalDb is a global database connection pointer

--- a/tile.go
+++ b/tile.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -34,7 +33,7 @@ func makeTile(vars map[string]string) (Tile, error) {
 	if !tile.IsValid() {
 		invalidTileError := tileAppError{
 			HTTPCode: 400,
-			SrcErr:   errors.New(fmt.Sprintf("invalid tile address %s", tile.String())),
+			SrcErr:   fmt.Errorf("invalid tile address %s", tile.String()),
 		}
 		return tile, invalidTileError
 	}

--- a/util.go
+++ b/util.go
@@ -212,6 +212,7 @@ type metricsResponseWriter struct {
 	StatusCode int
 }
 
+// NewMetricsResponseWriter instantiates and returns a metricsResponseWriter
 func NewMetricsResponseWriter(w http.ResponseWriter) *metricsResponseWriter {
 	return &metricsResponseWriter{w, http.StatusOK}
 }


### PR DESCRIPTION
I am unsure if this is helpful or not; if you'd rather I didn't do this then I'll also revert the changes in my fork.  I've simply gone through `gofmt`, `go vet`, and `go lint` as a way to get myself more familiar with the code, and applied all suggestions that wouldn't be a non-trivial code edit.  Some of the exported function comments are rather redundant, but I figure that having them in makes it easier to scan the rest of `go lint`'s output for more important feedback.