### PR TITLE
Configurable and very basic health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ After start-up you can connect to the server and explore the published tables an
 
 To disable the web interface, supply the run time flag `--no-preview`
 
+## Health Check Endpoint
+
+In order to run the server in an orchestrated environment, like Docker, it can be useful to have a health check endpoint. This is `/health` by default, and returns a `200 OK` if the server is responding to requests. To use a custom URL for the health check endpoint, supply the run time flag `-e` and your path. This setting will respect the base path setting, so if you choose a base path of `/example` and a health check endpoint of `/foo`, your health check URL becomes `/example/foo`.
+
 ## Layers List
 
 A list of layers is available in JSON at:

--- a/util_test.go
+++ b/util_test.go
@@ -48,7 +48,7 @@ func TestMetrics(t *testing.T) {
 	viper.Set("EnableMetrics", true)
 
 	r := tileRouter()
-	request, _ := http.NewRequest("GET", "/test/metrics", nil)
+	request, _ := http.NewRequest("GET", "/metrics", nil)
 	response := httptest.NewRecorder()
 	r.ServeHTTP(response, request)
 	assert.Equal(t, 200, response.Code, "OK response is expected")


### PR DESCRIPTION
The primary purpose of this change is to address #131 . 

It creates a simple endpoint, which only responds to `GET` requests. It responds with `200 OK` if the server up and running. By default, the endpoint is at `/health` under the `BasePath`, but you can set an alternative path for it using the `HealthEndpoint` config key or the command-line flag `-e`.

There was discussion of multiple endpoints in the issue, but I don't think I have the necessary context to decide when `startup` versus `readiness` ones should return a 200. Also, it sounds like people may want to supply multiple alternate paths; I have left that for another day.

While I was in there, I
- added some tests for functionality that @eldang added previously
- Displayed an error message on the command line when running the tests with a database that failed to create the `postgis` extension (in my case, it was because my test user didn't have permission). I don't know how common this scenario is, but it happened to me because I was starting the project up from scratch to take a look at making this change in particular.
