### PR TITLE
Use name -m to detect system arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CONTAINER ?= pramsey/$(PROGRAM)
 DATE ?= $(shell date +%Y%m%d)
 BASE_REGISTRY ?= registry.access.redhat.com
 BASE_IMAGE ?= ubi8-micro
-SYSTEMARCH = $(shell uname -i)
+SYSTEMARCH = $(shell uname -m)
 
 ifeq ($(SYSTEMARCH), x86_64)
 TARGETARCH ?= amd64


### PR DESCRIPTION
macOS uname does not have `-i` option, use `-m` to run both linux and macos.
