### PR TITLE
Use rtrim instead of trim

### DIFF
--- a/layer_table.go
+++ b/layer_table.go
@@ -503,7 +503,7 @@ func getTableLayers() ([]LayerTable, error) {
 		coalesce(d.description, '') AS description,
 		a.attname AS geometry_column,
 		postgis_typmod_srid(a.atttypmod) AS srid,
-		trim(trailing 'ZM' from postgis_typmod_type(a.atttypmod)) AS geometry_type,
+		rtrim(postgis_typmod_type(a.atttypmod), 'ZM') AS geometry_type,
 		coalesce(case when it.typname is not null then ia.attname else null end, '') AS id_column,
 		(
 			SELECT array_agg(ARRAY[sa.attname, st.typname, coalesce(da.description,''), sa.attnum::text]::text[] ORDER BY sa.attnum)


### PR DESCRIPTION
Some postgresql variant distrbution such as kingbase changed the behavior of trim to compatible with oracle, which trim does not support multi-charactor set. Use rtrim for compatibility.

