### PR TITLE
all JWT-based user impersonation/role-switching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/hugo/content/usage/security.md
+++ b/hugo/content/usage/security.md
@@ -42,3 +42,15 @@ REVOKE EXECUTE ON FUNCTION myschema.myfunction FROM public;
 -- Just to be sure, also revoke execute from the user
 REVOKE EXECUTE ON FUNCTION myschema.myfunction FROM tileserver;
 ```
+## Using JWT tokens for authentication
+
+[Like PostgREST](https://postgrest.org/en/v12/references/auth.html), `pg_tileserv` supports JWT-based user impersonation. This allows access to specific tables, views, or function to be restricted to authorized users.
+
+This is enabled by setting the `JwtSecret` key in the config file (or, equivalently, the `TS_JWTSECRET` environment variable).
+If this key is set, then `pg_tileserv` will initially connect to PostgreSQL as the "authenticator" user using the credentials in the `DbConnection` key of the config file.
+However, it will switch roles before executing queries.
+If a request includes a JWT token in an `Authorization` header, and it is signed with the correct secret, then `pg_tileserv` will attempt to switch to the role specified in the token (if the authenticator user lacks the permissions to do this, an error code will be returned).
+If the `Authorization` header is not present, then it switches to the role role defined by the `AnonRole` key (which has a default of "anonymous_user").
+
+The `JwtRoleClaimKey` configuration key specifies which claim on the JWT token should be interpreted as the name of the role to switch to; this defaults to `role`.
+

--- a/layer_proc.go
+++ b/layer_proc.go
@@ -176,7 +176,7 @@ func (lyr *LayerFunction) getFunctionDetailJSON(req *http.Request) (FunctionDeta
 	return td, nil
 }
 
-func getFunctionLayers() ([]LayerFunction, error) {
+func getFunctionLayers(databaseRole string) ([]LayerFunction, error) {
 
 	// Valid functions **must** have signature of
 	// function(z integer, x integer, y integer) returns bytea
@@ -200,7 +200,7 @@ func getFunctionLayers() ([]LayerFunction, error) {
 		ORDER BY 1
 		`
 
-	db, connerr := dbConnect()
+	db, connerr := dbConnectWithAuth(databaseRole)
 	if connerr != nil {
 		return nil, connerr
 	}

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ var globalTimeToLive = -1
 // A global array of Layer where the state is held for performance
 // Refreshed when LoadLayerTableList is called
 // Key is of the form: schemaname.tablename
-var globalLayers map[string]Layer
+var globalLayers map[string]map[string]Layer = make(map[string]map[string]Layer)
 var globalLayersMutex = &sync.Mutex{}
 
 /******************************************************************************/
@@ -102,6 +102,11 @@ func init() {
 	viper.SetDefault("CoordinateSystem.Ymax", 20037508.3427892)
 
 	viper.SetDefault("HealthEndpoint", "/health")
+
+	viper.SetDefault("JwtSecret", "")
+	viper.SetDefault("AnonRole", "anonymous_user")
+	viper.SetDefault("JwtRoleClaimKey", "role")
+
 }
 
 func main() {
@@ -190,7 +195,7 @@ func main() {
 
 	// Load the global layer list right away
 	// Also connects to database
-	if err := loadLayers(); err != nil {
+	if err := loadLayers(""); err != nil {
 		log.Fatal(err)
 	}
 
@@ -228,11 +233,16 @@ func requestPreview(w http.ResponseWriter, r *http.Request) error {
 	// reqBuffer := r.FormValue("buffer")
 
 	// Refresh the layers list
-	if err := loadLayers(); err != nil {
+	databaseRole, err := getDatabaseRoleFromRequest(r)
+	if err != nil {
+		return err
+	}
+
+	if err := loadLayers(databaseRole); err != nil {
 		return err
 	}
 	// Get the requested layer
-	lyr, err := getLayer(lyrID)
+	lyr, err := getLayer(lyrID, databaseRole)
 	if err != nil {
 		errLyr := tileAppError{
 			HTTPCode: 404,
@@ -269,10 +279,15 @@ func requestListHTML(w http.ResponseWriter, r *http.Request) error {
 	}).Trace("requestListHtml")
 	// Update the global in-memory list from
 	// the database
-	if err := loadLayers(); err != nil {
+	databaseRole, err := getDatabaseRoleFromRequest(r)
+	if err != nil {
 		return err
 	}
-	jsonLayers := getJSONLayers(r)
+
+	if err := loadLayers(databaseRole); err != nil {
+		return err
+	}
+	jsonLayers := getJSONLayers(r, databaseRole)
 
 	content, err := ioutil.ReadFile(fmt.Sprintf("%s/index.html", viper.GetString("AssetsPath")))
 
@@ -294,13 +309,19 @@ func requestListJSON(w http.ResponseWriter, r *http.Request) error {
 		"event": "request",
 		"topic": "layerlist",
 	}).Trace("requestListJSON")
+
 	// Update the global in-memory list from
 	// the database
-	if err := loadLayers(); err != nil {
+	databaseRole, err := getDatabaseRoleFromRequest(r)
+	if err != nil {
+		return err
+	}
+
+	if err := loadLayers(databaseRole); err != nil {
 		return err
 	}
 	w.Header().Add("Content-Type", "application/json")
-	jsonLayers := getJSONLayers(r)
+	jsonLayers := getJSONLayers(r, databaseRole)
 	json.NewEncoder(w).Encode(jsonLayers)
 	return nil
 }
@@ -313,11 +334,15 @@ func requestDetailJSON(w http.ResponseWriter, r *http.Request) error {
 	}).Tracef("requestDetailJSON(%s)", lyrID)
 
 	// Refresh the layers list
-	if err := loadLayers(); err != nil {
+	databaseRole, err := getDatabaseRoleFromRequest(r)
+	if err != nil {
+		return err
+	}
+	if err := loadLayers(databaseRole); err != nil {
 		return err
 	}
 
-	lyr, err := getLayer(lyrID)
+	lyr, err := getLayer(lyrID, databaseRole)
 	if err != nil {
 		errLyr := tileAppError{
 			HTTPCode: 404,
@@ -334,10 +359,16 @@ func requestDetailJSON(w http.ResponseWriter, r *http.Request) error {
 }
 
 // requestTile handles a tile request for a given layer
-func requestTile(r *http.Request, source string) ([]byte, error) {
+func requestTile(r *http.Request, source string, databaseRole string) ([]byte, error) {
+
 	vars := mux.Vars(r)
 
-	lyr, err := getLayer(source)
+	databaseRole, err := getDatabaseRoleFromRequest(r)
+	if err != nil {
+		return nil, err
+	}
+
+	lyr, err := getLayer(source, databaseRole)
 	if err != nil {
 		errLyr := tileAppError{
 			HTTPCode: 404,
@@ -361,7 +392,7 @@ func requestTile(r *http.Request, source string) ([]byte, error) {
 	defer cancel()
 
 	tilerequest := lyr.GetTileRequest(tile, r)
-	mvt, errMvt := dBTileRequest(ctx, &tilerequest)
+	mvt, errMvt := dBTileRequest(ctx, &tilerequest, databaseRole)
 	if errMvt != nil {
 		return nil, errMvt
 	}
@@ -371,6 +402,18 @@ func requestTile(r *http.Request, source string) ([]byte, error) {
 
 // requestTiles handles a tile request for a given layer, including multi layer tile requests
 func requestTiles(w http.ResponseWriter, r *http.Request) error {
+
+	// Handle CORS preflight requests
+	// we don't need to return any content in the response body - just the correct headers
+	if r.Method == http.MethodOptions {
+		return nil
+	}
+
+	databaseRole, err := getDatabaseRoleFromRequest(r)
+	if err != nil {
+		return err
+	}
+
 	var layers []byte
 	vars := mux.Vars(r)
 
@@ -378,7 +421,7 @@ func requestTiles(w http.ResponseWriter, r *http.Request) error {
 	var extant []string
 	for _, source := range sources {
 		if !slices.Contains(extant, source) {
-			layer, err := requestTile(r, source)
+			layer, err := requestTile(r, source, databaseRole)
 			if err != nil {
 				return err
 			}
@@ -498,7 +541,6 @@ func tileRouter() *mux.Router {
 	}
 	// Tile requests
 	r.Handle("/{name}/{z:[0-9]+}/{x:[0-9]+}/{y:[0-9]+}.{ext}", tileMetrics(tileAppHandler(requestTiles)))
-
 	if viper.GetBool("EnableMetrics") {
 		r.Handle("/metrics", promhttp.Handler())
 	}
@@ -515,6 +557,7 @@ func handleRequests() {
 	// Allow CORS from anywhere
 	corsOrigins := viper.GetStringSlice("CORSOrigins")
 	corsOpt := handlers.AllowedOrigins(corsOrigins)
+	corsHeadersOpt := handlers.AllowedHeaders([]string{"Authorization"})
 
 	// Set a writeTimeout for the http server.
 	// This value is the application's DbTimeout config setting plus a
@@ -530,7 +573,7 @@ func handleRequests() {
 		ReadTimeout:  1 * time.Second,
 		WriteTimeout: writeTimeout,
 		Addr:         fmt.Sprintf("%s:%d", viper.GetString("HttpHost"), viper.GetInt("HttpPort")),
-		Handler:      setCacheControl(handlers.CompressHandler(handlers.CORS(corsOpt)(r))),
+		Handler:      setCacheControl(handlers.CompressHandler(handlers.CORS(corsOpt, corsHeadersOpt)(r))),
 	}
 
 	// start http service

--- a/token.go
+++ b/token.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	// Config
+	"github.com/spf13/viper"
+
+	// JWT Tokens
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func parseToken(tokenString string) (string, error) {
+	jwtSecret := []byte(viper.GetString("JwtSecret"))
+	jwtAudience := viper.GetString("JwtAudience")
+	jwtRoleClaimKey := viper.GetString("JwtRoleClaimKey")
+
+	// Parse the token from the request
+
+	fmt.Println("jwtSecret", jwtSecret)
+	fmt.Println("tokenString", tokenString)
+
+	// Parse takes the token string and a function for looking up the key. The latter is especially
+	// useful if you use multiple keys for your application.  The standard is to use 'kid' in the
+	// head of the token to identify which key to use, but the parsed token (head and claims) is provided
+	// to the callback, providing flexibility.
+
+	keyFunc := func(token *jwt.Token) (interface{}, error) {
+		// Don't forget to validate the alg is what you expect:
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+
+		return jwtSecret, nil
+	}
+
+	var token *jwt.Token
+	err := error(nil)
+	if jwtAudience == "" {
+		token, err = jwt.Parse(tokenString, keyFunc)
+	} else {
+		token, err = jwt.Parse(tokenString, keyFunc, jwt.WithAudience(jwtAudience))
+	}
+
+	if err != nil {
+		return "", tileAppError{
+			SrcErr:   err,
+			Message:  fmt.Sprintf("Failed to parse JWT token"),
+			HTTPCode: http.StatusBadRequest,
+		}
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", tileAppError{
+			SrcErr:   err,
+			Message:  fmt.Sprintf("Failed to extract claims from JWT token"),
+			HTTPCode: http.StatusBadRequest,
+		}
+	}
+
+	return fmt.Sprintf("%s", claims[jwtRoleClaimKey]), nil
+}
+
+func getDatabaseRole(authHeader string) (string, error) {
+	jwtSecret := viper.GetString("JwtSecret")
+	anonRole := viper.GetString("AnonRole")
+
+	// if JWT auth not configured, return empty string - queries should be run as the configured user
+	if jwtSecret == "" {
+		return "", nil
+	}
+
+	// if no auth header, queries should run as anon user
+	if authHeader == "" {
+		return anonRole, nil
+	}
+
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+
+	if tokenString == "" {
+		return "", tileAppError{
+			//SrcErr:  err,
+			Message:  fmt.Sprintf("Request included Authorization header, but this did not include a token"),
+			HTTPCode: http.StatusBadRequest,
+		}
+	}
+
+	// otherwise, determine which role was specified in the token
+	newRole, err := parseToken(tokenString)
+	return newRole, err
+}
+
+func getAuthHeader(r *http.Request) string {
+	authHeader := ""
+	if authorization, ok := r.Header["Authorization"]; ok {
+		authHeader = authorization[0]
+	}
+	return authHeader
+}
+
+func getDatabaseRoleFromRequest(r *http.Request) (string, error) {
+	authHeader := getAuthHeader(r)
+	return getDatabaseRole(authHeader)
+}


### PR DESCRIPTION
This PR allow users to supply a JWT token as an `Authorization` header when making requests.

If configured to allow this, `pg_tileserv` will check the signature on the token, look in a specific field of the claims to extract a database role name, and switch to that role before running database queries. If no token is provided, it will switch to a designated anonymous_user role.

This mechanism allows access to certain tables to be restricted to authorized users.