### PR TITLE
Projection bounds from db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,19 +14,21 @@ APPVERSION ?= latest
 GOVERSION ?= 1.21.6
 PROGRAM ?= pg_tileserv
 CONFIG ?= config/$(PROGRAM).toml
-CONTAINER ?= pramsey/$(PROGRAM)
+CONTAINER ?= harbor.internal.millcrest.dev/library/$(PROGRAM)
 DATE ?= $(shell date +%Y%m%d)
 BASE_REGISTRY ?= registry.access.redhat.com
 BASE_IMAGE ?= ubi8-micro
 SYSTEMARCH = $(shell uname -i)
 
-ifeq ($(SYSTEMARCH), x86_64)
+# ifeq ($(SYSTEMARCH), x86_64)
+# TARGETARCH ?= amd64
+# PLATFORM=amd64
+# else
+# TARGETARCH ?= arm64
+# PLATFORM=arm64
+# endif
 TARGETARCH ?= amd64
-PLATFORM=amd64
-else
-TARGETARCH ?= arm64
-PLATFORM=arm64
-endif
+PLATFORM ?= amd64
 
 IMAGE_TAG ?= $(APPVERSION)-$(TARGETARCH)
 DATE_TAG ?= $(DATE)-$(TARGETARCH)
@@ -83,6 +85,9 @@ build-common: Dockerfile
 		--label os.version="7.7" \
 		-t $(CONTAINER):$(IMAGE_TAG) -t $(CONTAINER):$(DATE_TAG) .
 	docker image prune --filter label=stage=tileservbuilder -f
+
+push-docker:
+	docker push ${CONTAINER}:${IMAGE_TAG}
 
 set-local:
 	$(eval BUILDTYPE = local)

--- a/bounds.go
+++ b/bounds.go
@@ -29,7 +29,7 @@ func (b *Bounds) SQL() string {
 // Expand increases the size of this bounds in all directions, respecting
 // the limits of the Web Mercator plane
 func (b *Bounds) Expand(size float64) {
-	serverBounds, _ := getServerBounds()
+	serverBounds, _ := getServerBounds(nil)
 	b.Xmin = math.Max(b.Xmin-size, serverBounds.Xmin)
 	b.Ymin = math.Max(b.Ymin-size, serverBounds.Ymin)
 	b.Xmax = math.Min(b.Xmax+size, serverBounds.Xmax)

--- a/config/pg_tileserv.toml.example
+++ b/config/pg_tileserv.toml.example
@@ -71,6 +71,9 @@
 # Metrics will be exported at `/metrics`.
 # EnableMetrics = false
 
+# Table in the database that contains projections with bounds (must have columns: srid, x_min, y_min, x_max, y_max)
+# ProjectionBoundsTableName = "common.projection"
+
 # Default CS is Web Mercator (EPSG:3857)
 # DefaultCoordinateSystem = 3857
 # [CoordinateSystem.3857]

--- a/config/pg_tileserv.toml.example
+++ b/config/pg_tileserv.toml.example
@@ -72,16 +72,15 @@
 # EnableMetrics = false
 
 # Default CS is Web Mercator (EPSG:3857)
-# [CoordinateSystem]
-# SRID = 3857
+# DefaultCoordinateSystem = 3857
+# [CoordinateSystem.3857]
 # Xmin = -20037508.3427892
 # Ymin = -20037508.3427892
 # Xmax = 20037508.3427892
 # Ymax = 20037508.3427892
 
 # "True" Mercator (EPSG:3395) is only a little different
-# [CoordinateSystem]
-# SRID = 3395
+# [CoordinateSystem.3395]
 # Xmin = -20037508.342789244
 # Ymin = -20037508.342789244
 # Xmax = 20037508.342789244

--- a/db.go
+++ b/db.go
@@ -23,48 +23,49 @@ import (
 )
 
 func dbConnect() (*pgxpool.Pool, error) {
-	if globalDb == nil {
-		var err error
-		var config *pgxpool.Config
-		dbConnection := viper.GetString("DbConnection")
-		config, err = pgxpool.ParseConfig(dbConnection)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Read and parse connection lifetime
-		dbPoolMaxLifeTime, errt := time.ParseDuration(viper.GetString("DbPoolMaxConnLifeTime"))
-		if errt != nil {
-			log.Fatal(errt)
-		}
-		config.MaxConnLifetime = dbPoolMaxLifeTime
-
-		// Read and parse max connections
-		dbPoolMaxConns := viper.GetInt32("DbPoolMaxConns")
-		if dbPoolMaxConns > 0 {
-			config.MaxConns = dbPoolMaxConns
-		}
-
-		// Read current log level and use one less-fine level
-		// below that
-		config.ConnConfig.Logger = logrusadapter.NewLogger(log.New())
-		levelString, _ := (log.GetLevel() - 1).MarshalText()
-		pgxLevel, _ := pgx.LogLevelFromString(string(levelString))
-		config.ConnConfig.LogLevel = pgxLevel
-
-		// Connect!
-		globalDb, err = pgxpool.ConnectConfig(context.Background(), config)
-		if err != nil {
-			log.Fatal(err)
-		}
-		dbName := config.ConnConfig.Config.Database
-		dbUser := config.ConnConfig.Config.User
-		dbHost := config.ConnConfig.Config.Host
-		log.Infof("Connected as '%s' to '%s' @ '%s'", dbUser, dbName, dbHost)
-
-		return globalDb, err
+	if globalDb != nil {
+		return globalDb, nil
 	}
-	return globalDb, nil
+
+	var err error
+	var config *pgxpool.Config
+	dbConnection := viper.GetString("DbConnection")
+	config, err = pgxpool.ParseConfig(dbConnection)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Read and parse connection lifetime
+	dbPoolMaxLifeTime, errt := time.ParseDuration(viper.GetString("DbPoolMaxConnLifeTime"))
+	if errt != nil {
+		log.Fatal(errt)
+	}
+	config.MaxConnLifetime = dbPoolMaxLifeTime
+
+	// Read and parse max connections
+	dbPoolMaxConns := viper.GetInt32("DbPoolMaxConns")
+	if dbPoolMaxConns > 0 {
+		config.MaxConns = dbPoolMaxConns
+	}
+
+	// Read current log level and use one less-fine level
+	// below that
+	config.ConnConfig.Logger = logrusadapter.NewLogger(log.New())
+	levelString, _ := (log.GetLevel() - 1).MarshalText()
+	pgxLevel, _ := pgx.LogLevelFromString(string(levelString))
+	config.ConnConfig.LogLevel = pgxLevel
+
+	// Connect!
+	globalDb, err = pgxpool.ConnectConfig(context.Background(), config)
+	if err != nil {
+		log.Fatal(err)
+	}
+	dbName := config.ConnConfig.Config.Database
+	dbUser := config.ConnConfig.Config.User
+	dbHost := config.ConnConfig.Config.Host
+	log.Infof("Connected as '%s' to '%s' @ '%s'", dbUser, dbName, dbHost)
+
+	return globalDb, err
 }
 
 func loadVersions() error {
@@ -134,4 +135,28 @@ func dBTileRequest(ctx context.Context, tr *TileRequest) ([]byte, error) {
 
 	}
 	return mvtTile, nil
+}
+
+func dBProjectionBoundsRequest(ctx context.Context, srid int) (float64, float64, float64, float64, error) {
+	db, err := dbConnect()
+	if err != nil {
+		log.Error(err)
+		return 0, 0, 0, 0, err
+	}
+	boundsSQL := fmt.Sprintf(
+		"SELECT x_min, y_min, x_max, y_max FROM %s WHERE srid = $1",
+		globalProjectionBoundsTableName,
+	)
+	row := db.QueryRow(ctx, boundsSQL, srid)
+
+	var (
+		xmin, ymin, xmax, ymax float64
+	)
+	err = row.Scan(&xmin, &ymin, &xmax, &ymax)
+	if err != nil {
+		log.Warn(err)
+		return 0, 0, 0, 0, fmt.Errorf("failed to get bounds from database: %w", err)
+
+	}
+	return xmin, ymin, xmax, ymax, nil
 }

--- a/layer.go
+++ b/layer.go
@@ -59,7 +59,7 @@ func getLayer(lyrID string) (Layer, error) {
 }
 
 func loadLayers() error {
-	_, errBnd := getServerBounds()
+	_, errBnd := getServerBounds(nil)
 	if errBnd != nil {
 		return errBnd
 	}

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ var globalPostGISVersion int
 // which tiles are constructed
 var globalServerBounds = make(map[int]*Bounds)
 var globalDefaultCoordinateSystem int
+var globalProjectionBoundsTableName string
 
 // timeToLive is the Cache-Control timeout value that will be advertised
 // in the response headers
@@ -197,6 +198,8 @@ func main() {
 
 	globalDefaultCoordinateSystem = viper.GetInt("DefaultCoordinateSystem")
 	log.Infof("Default CoordinateSystem: %d", globalDefaultCoordinateSystem)
+
+	globalProjectionBoundsTableName = viper.GetString("ProjectionBoundsTableName")
 
 	// Load the global layer list right away
 	// Also connects to database

--- a/tile.go
+++ b/tile.go
@@ -20,7 +20,7 @@ type Tile struct {
 // makeTile uses the map populated by the mux.Router
 // containing x, y and z keys, and extracts integers
 // from them
-func makeTile(vars map[string]string) (Tile, error) {
+func makeTile(vars map[string]string, srid *int) (Tile, error) {
 	// Router path restriction ensures
 	// these are always numbers
 	x, _ := strconv.Atoi(vars["x"])
@@ -37,7 +37,7 @@ func makeTile(vars map[string]string) (Tile, error) {
 		}
 		return tile, invalidTileError
 	}
-	e := tile.CalculateBounds()
+	e := tile.CalculateBounds(srid)
 	return tile, e
 }
 
@@ -63,8 +63,8 @@ func (tile *Tile) IsValid() bool {
 
 // CalculateBounds calculates the cartesian bounds that
 // correspond to this tile
-func (tile *Tile) CalculateBounds() (e error) {
-	serverBounds, e := getServerBounds()
+func (tile *Tile) CalculateBounds(srid *int) (e error) {
+	serverBounds, e := getServerBounds(srid)
 	if e != nil {
 		return e
 	}

--- a/tile_test.go
+++ b/tile_test.go
@@ -8,7 +8,7 @@ import (
 func Test_makeTile(t *testing.T) {
 	// func makeTile(vars map[string]string) (Tile, error) {
 
-	serverBounds, _ := getServerBounds()
+	serverBounds, _ := getServerBounds(nil)
 
 	var tests = []struct {
 		input   map[string]string
@@ -23,7 +23,7 @@ func Test_makeTile(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if output, err := makeTile(test.input); test.outtile != output || test.outerr != err {
+		if output, err := makeTile(test.input, nil); test.outtile != output || test.outerr != err {
 			t.Error("Test Failed: {} inputted, {} expected, recieved: {}, {}", test.input, test.outtile, output, err)
 		}
 	}


### PR DESCRIPTION
Coordinate system bounds can now be fetched from the database. For example from the table `common.projection` which has the following columns: `srid, x_min, y_min, x_max, y_max`